### PR TITLE
Fixes #17

### DIFF
--- a/edd-auto-register.php
+++ b/edd-auto-register.php
@@ -379,12 +379,16 @@ if ( ! class_exists( 'EDD_Auto_Register' ) ) {
 			// Guest purchasing disabled
 			if ( edd_no_guest_checkout() ) {
 
-				// Not logged in so force login
-				if ( ! is_user_logged_in() )
+				if ( ! is_user_logged_in() ) {
+
+					// Not logged in so force login
 					$value = 'login';
 
-				// No form if logged in
-				else $value = 'none';
+				} else {
+
+					// No form if logged in
+					$value = 'none';
+				}
 			
 			} elseif ( ( 'both' === $value || 'registration' === $value ) ) {
 				

--- a/edd-auto-register.php
+++ b/edd-auto-register.php
@@ -134,10 +134,6 @@ if ( ! class_exists( 'EDD_Auto_Register' ) ) {
 			// Ensure registration form is never shown
 			add_filter( 'edd_get_option_show_register_form', array( $this, 'remove_register_form' ), 10, 3 );
 
-			// Force guest checkout to be enabled
-			add_filter( 'edd_no_guest_checkout', '__return_false' );
-			add_filter( 'edd_logged_in_only', '__return_false' );
-
 			do_action( 'edd_auto_register_setup_actions' );
 		}
 
@@ -374,14 +370,26 @@ if ( ! class_exists( 'EDD_Auto_Register' ) ) {
 		}
 
 		/**
-		 * Removes the registration form and changes it to a log in form
+		 * Change the registration form depending on a few conditions
 		 *
 		 * @since 1.3
 		 */
 		public function remove_register_form( $value, $key, $default ) {
 
-			if ( 'both' === $value || 'registration' === $value ) {
-				$value = 'login';
+			// Guest purchasing disabled
+			if ( edd_no_guest_checkout() ) {
+
+				// Not logged in so force login
+				if ( ! is_user_logged_in() )
+					$value = 'login';
+
+				// No form if logged in
+				else $value = 'none';
+			
+			} elseif ( ( 'both' === $value || 'registration' === $value ) ) {
+				
+				// Always remove registration form
+				$value = 'none';
 			}
 
 			return $value;


### PR DESCRIPTION
Issue #17 

For this, I removed a couple of filters that were being added to always return false on the check of the logged_in_only option. These didn't make sense to me and my fix involved directly checking this value, which wasn't possible with these filters forcing it to false.

Next, I modified the remove_register_form() method to be based on the logged_in_only option:

* If the option is enabled (guest purchases are not allowed), it checks to see if the user is not logged in and returns the login form if not. Otherwise, it returns no form for logged in users.
* If the option is not enabled but the registration form is set to show, it is removed.